### PR TITLE
Add parameter to dump data for single user

### DIFF
--- a/app/controllers/course/api_controller.rb
+++ b/app/controllers/course/api_controller.rb
@@ -40,7 +40,7 @@ class Course::ApiController < Admin::AdminController
             (confirmed.nil? || all_confirmations_checked(u, confirmed))
         }
       else
-        return error("user not found") if user.staff? != dumpStaff
+        return error("user not found") unless user.staff? == dumpStaff
 
         [user]
       end


### PR DESCRIPTION
This adds a parameter to dump the data of a single user from the forum. This way, the authentication from the handin-server does not have to pull the whole user database, which takes rather long.